### PR TITLE
販売ステータス更新不可修正

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -2,8 +2,8 @@ class Admin::HomesController < ApplicationController
   before_action :authenticate_admin!
 
   def top
-    @order = Order.order(created_at: :desc).page(params[:page]).per(4)
-    @orders = Order.all
+    @orders = Order.order(created_at: :desc).page(params[:page]).per(8)
+    
   end
 
   private

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -2,6 +2,9 @@ class Public::CartItemsController < ApplicationController
   before_action :authenticate_customer!
   def index
     @cart_items = current_customer.cart_items
+    @inactive_items = @cart_items.select {|cart_item| !cart_item.item.is_active}      
+  # カート内に販売停止中の商品があれば、進行を制限するフラグを渡す
+    @has_inactive_items = @inactive_items.any?
   end
 
   def update

--- a/app/controllers/public/home_controller.rb
+++ b/app/controllers/public/home_controller.rb
@@ -1,7 +1,7 @@
 class Public::HomeController < ApplicationController
   def top
     #作成日時（created_at）を基準に降順（:desc）で並び替える
-    @items = Item.order(created_at: :desc).limit(4)
+    @items = Item.where(is_active: true).order(created_at: :desc).limit(4)  # 販売中の最新の4つを取得
   end
 
   def about

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,6 +1,6 @@
 class Public::ItemsController < ApplicationController
   def index
-    @items = Item.page(params[:page]).per(8) # ← 1ページに8件ずつ表示
+    @items = Item.where(is_active: true).page(params[:page]).per(8) # ← 1ページに8件ずつ表示
   end
 
   def show

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -67,7 +67,7 @@ class Public::OrdersController < ApplicationController
 
   def index
     @customer = current_customer
-    @orders = @customer.orders.includes(:order_details).order(crested_at: :desc)
+    @orders = @customer.orders.includes(:order_details).order(created_at: :desc)
   end
 
   def show

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -28,7 +28,7 @@
     </table>
 
     <div class="d-flex justify-content-center">
-      <%= paginate @order, theme: 'bootstrap-5' %>
+      <%= paginate @orders, theme: 'bootstrap-5' %>
     </div>
   </div>
 </div>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -10,35 +10,40 @@
     </div>
   <% end %>
   <h2>商品情報編集</h2>
-  <table class="table table-borderless m-4">
-    <%= form_with model: @item, url: admin_item_path(@item), method: :patch, local: true do |f| %>
-    <tr>
-      <td>商品名</td>
-      <td><%= f.text_field :name %></td>
-    </tr>
-    <tr>
-      <td>ジャンル</td>
-      <td><%= f.collection_select :genre_id, Genre.all, :id, :name, { prompt: 'ジャンルを選択' } %></td>
-    </tr>
-    <tr>
-      <td>価格(税抜)</td>
-      <td><%= f.number_field :price %></td>
-    </tr>
-    <tr>
-      <td>販売ステータス</td>
-      <td><%= f.radio_button :is_active, true %><%= f.label :is_active_true, '販売中' %>
-          <%= f.radio_button :is_active, false %><%= f.label :is_active_false, '販売停止中' %></td>
-    </tr>
-    <tr>
-      <td>商品画像</td>
-      <td><%= f.file_field :image %></td>
-    </tr>
-    <tr>
-      <td>商品説明文</td>
-      <td><%= f.text_area :introduction %></td>
-    </tr>
-  </table>
-  <%= f.submit '更新',class:"btn btn-sm btn-outline-success m-3" %>
+  <%= form_with model: @item, url: admin_item_path(@item), method: :patch, local: true do |f| %>
+    <table class="table table-borderless m-4">
+      <tr>
+        <td>商品名</td>
+        <td><%= f.text_field :name %></td>
+      </tr>
+      <tr>
+        <td>ジャンル</td>
+        <td><%= f.collection_select :genre_id, Genre.all, :id, :name, { prompt: 'ジャンルを選択' } %></td>
+      </tr>
+      <tr>
+        <td>価格(税抜)</td>
+        <td><%= f.number_field :price %></td>
+      </tr>
+      <tr>
+        <td>販売ステータス</td>
+        <td><%= f.radio_button :is_active, true, checked: f.object.is_active == true %>
+            <%= f.label :is_active_true, '販売中' %>
+    
+            <%= f.radio_button :is_active, false, checked: f.object.is_active == false %>
+            <%= f.label :is_active_false, '販売停止中' %>
+      </tr>
+      <tr>
+        <td>商品画像</td>
+        <td><%= f.file_field :image %></td>
+      </tr>
+      <tr>
+        <td>商品説明文</td>
+        <td><%= f.text_area :introduction %></td>
+      </tr>
+    </table>
+    <div class="d-flex justify-content-start gap-3 mt-3">
+      <%= f.submit '更新',class:"btn btn-sm btn-outline-success m-3" %>
+      <%= link_to '戻る', admin_items_path,class:"btn btn-sm btn-outline-secondary m-3" %>
+    </div>
   <% end %>
-  <%= link_to '戻る', admin_items_path,class:"btn btn-sm btn-outline-secondary m-3" %>
 </div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -7,11 +7,19 @@
       <div class="col d-flex align-items-stretch"> <!-- 高さも揃える -->
         <div class="card shadow-sm w-100 h-100 d-flex flex-column"> <!-- 幅と高さを統一 -->
           <%= link_to admin_item_path(item), class: "text-decoration-none text-dark" do %>
-            <% if item.image.attached? %>
-              <%= image_tag item.image, class: "card-img-top", style: "height: 200px; object-fit: cover;" %>
-            <% else %>
-              <%= image_tag 'no_image.jpg', class: "card-img-top", style: "height: 200px; object-fit: cover;" %>
-            <% end %>
+            <div class="position-relative">          
+              <% if item.image.attached? %>
+                <%= image_tag item.image, class: "card-img-top", style: "height: 200px; object-fit: cover;" %>
+              <% else %>
+                <%= image_tag 'no_image.jpg', class: "card-img-top", style: "height: 200px; object-fit: cover;" %>
+              <% end %>
+
+              <% if !item.is_active %>  <!-- 販売停止中の場合 -->
+                <div class="position-absolute top-50 start-50 translate-middle text-white bg-danger p-2" style="font-size: 1.5rem; opacity: 0.8;">
+                  販売停止
+                </div>
+              <% end %>
+            </div>
           <% end %>
 
           <div class="card-body text-center flex-grow-1"> <!-- 高さを均等に -->

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,6 +1,15 @@
 <div class = "container">
   <h2 class = "mt-4">ショッピングカート</h2>
 
+  <% if @inactive_items.any? %>
+    <div class="alert alert-warning">
+      <strong>注意!</strong> 一部の商品は販売停止中のため、カートから削除してください。
+    </div>
+    <% @inactive_items.each do |inactive_item| %>
+      <%= link_to "削除", cart_item_path(inactive_item), method: :delete, class: "btn btn-sm btn-danger" %>
+    <% end %>
+  <% end %>
+
     <div class = "row m-2">
       <table class='table table-hover table-inverse'>
         <thead>
@@ -13,6 +22,7 @@
           </tr>
         </thead>
         <% @cart_items.each do |cart_item| %>
+        
           <tbody>
             <tr>
               <td><!--写真と商品名-->
@@ -41,6 +51,7 @@
               </td>
             </tr>
           </tbody>
+        
         <% end %>
       </table>
 
@@ -59,8 +70,9 @@
       </div>
 
       </div> 
-        <%= link_to "Topへ戻る", root_path, class: "btn btn-sm btn-outline-secondary ml-3" %>
-        <% if @cart_items.present? %>
+        <%= link_to "買い物を続ける（Topへ）", root_path, class: "btn btn-sm btn-outline-secondary ml-3" %>
+        <%= link_to "買い物を続ける（商品一覧）", items_path, class: "btn btn-sm btn-outline-primary ml-3" %>
+        <% if @cart_items.present?&& !@has_inactive_items %>
           <%= link_to "情報入力に進む", new_order_path, class: "btn btn-sm btn-outline-success ml-3" %><br>
         <% else %>
         <% end %>

--- a/app/views/public/home/about.html.erb
+++ b/app/views/public/home/about.html.erb
@@ -22,14 +22,15 @@
 
   .overlay-text {
     position: absolute;
-    top: 50%; /* 画像の中央に配置 */
+    top: 23%; /* 画像の上部に配置 */
     left: 50%;
     transform: translate(-50%, -50%); /* 中央に配置するためのオフセット */
     color: white; /* 文字色 */
     font-size: 1.2rem; /* フォントサイズ */
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.6); /* 文字の影をつけて読みやすくする */
     z-index: 1; /* 画像より前面に表示 */
-    max-width: 80%; /* 文字が広がりすぎないように調整 */
+    max-width: 100%; /* 文字が広がりすぎないように調整 */
+    font-size: clamp(0.8rem, 3vw, 1.2rem) /* 最小サイズ, 推奨サイズ, 最大サイズ */
   }
   </style>
 </div>

--- a/app/views/public/home/top.html.erb
+++ b/app/views/public/home/top.html.erb
@@ -1,11 +1,13 @@
 <div class="container">
   <div class="row">
-    <div class="text-center overlay-text">
-      <p>ようこそ、ながのCAKEへ!</p>
-      <p>このサイトはケーキ販売のECサイトになります。</p>
-      <p>会員でない方も商品の閲覧はできますが、</p>
-      <p>購入には会員登録が必要になります。</p>
-    </div>
+    <% if current_customer.nil? %>
+      <div class="text-center overlay-text">
+        <p>ようこそ、ながのCAKEへ!</p>
+        <p>このサイトはケーキ販売のECサイトになります。</p>
+        <p>会員でない方も商品の閲覧はできますが、</p>
+        <p>購入には会員登録が必要になります。</p>
+      </div>
+    <% end %>
   </div>
 
   <!-- トップ画像の表示 -->
@@ -22,30 +24,36 @@
   .top-image {
     width: 100%; /* 画像を横幅100%で表示 */
     height: auto;
+    margin-top: 20px; /* フラッシュメッセージ分の余白を確保 */
   }
 
   .overlay-text {
     position: absolute;
-    top: 50%; /* 画像の中央に配置 */
+    top: 30%; /* 画像の上部に配置 */
     left: 50%;
     transform: translate(-50%, -50%); /* 中央に配置するためのオフセット */
     color: white; /* 文字色 */
-    font-size: 1.2rem; /* フォントサイズ */
+    font-size: clamp(0.8rem, 3vw, 1.2rem) /* フォントサイズ  最小サイズ, 推奨サイズ, 最大サイズ */
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.6); /* 文字の影をつけて読みやすくする */
     z-index: 1; /* 画像より前面に表示 */
-    max-width: 80%; /* 文字が広がりすぎないように調整 */
+    max-width: 100%; /* 文字が広がりすぎないように調整 */
+    
+    display: inline-block; /* テキスト範囲だけに背景を適用 */
+    background: rgba(0, 0, 0, 0.5); /* 半透明の黒い背景 */
+    padding: 10px 15px; /* 余白を追加 */
+    border-radius: 8px; /* 角を丸くして柔らかい印象に */
   }
 
 </style>
 
   <h4 class="text-center my-3">新着商品一覧</h4><!-- カードを正方形に変更して画像が横伸びしないように -->
   <!-- カードリストとボタンを横並びに配置 -->
-  <div class="d-flex justify-content-center align-items-end">
+  <div class="d-flex flex-column align-items-center">
     <!-- カードリスト -->
 
-    <div class="card-list-container d-flex flex-wrap justify-content-center">
+    <div class="card-list-container d-flex flex-wrap justify-content-center w-100">
       <% @items.each do |item| %>
-        <div class="card m-3 shadow-lg" style="width: 200px; height: 280px;">
+        <div class="card m-1 shadow-lg" style="width: 200px; height: 280px;">
           <%= link_to item_path(item) do %>
             <% if item.image.attached? %>
               <%= image_tag item.image, class: "card-img-top", style: "width: 100%; height: 200px; object-fit: cover;" %>
@@ -63,7 +71,7 @@
         </div>
       <% end %>
     </div>
-    <div class="text-center mt-3">
+    <div class="text-center mt-3 my-3">
       <%= link_to "すべての商品を見る >", items_path, class: "btn btn-outline-info" %>
     </div>
   </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -4,22 +4,24 @@
 
     <div class="card-list-container d-flex flex-wrap justify-content-center">
       <% @items.each do |item| %>
-        <div class="card m-3 shadow-lg" style="width: 200px; height: 280px;">
-          <%= link_to item_path(item) do %>
-            <% if item.image.attached? %>
-              <%= image_tag item.image, class: "card-img-top", style: "width: 100%; height: 200px; object-fit: cover;" %>
-            <% else %>
-              <%= image_tag 'no_image.jpg', class: "card-img-top", style: "width: 100%; height: 200px; object-fit: cover;" %>
+        <% if item.is_active %>  <!-- 販売中の商品だけ表示 -->
+          <div class="card m-3 shadow-lg" style="width: 200px; height: 280px;">
+            <%= link_to item_path(item) do %>
+              <% if item.image.attached? %>
+                <%= image_tag item.image, class: "card-img-top", style: "width: 100%; height: 200px; object-fit: cover;" %>
+              <% else %>
+                <%= image_tag 'no_image.jpg', class: "card-img-top", style: "width: 100%; height: 200px; object-fit: cover;" %>
+              <% end %>
             <% end %>
-          <% end %>
 
-          <div class="card-body text-center"><!-- 文字数多くてはみ出る場合は省略 -->
-            <h5 class="card-title text-truncate" style="max-width: 180px; font-size: clamp(12px, 1.5vw, 16px);">
-              <%= item.name %>
-            </h5>
-            <p class="card-price" style="font-size: clamp(12px, 1.2vw, 14px);"><%= (item.price * 1.1).floor %>円</p>
+            <div class="card-body text-center"><!-- 文字数多くてはみ出る場合は省略 -->
+              <h5 class="card-title text-truncate" style="max-width: 180px; font-size: clamp(12px, 1.5vw, 16px);">
+                <%= item.name %>
+              </h5>
+              <p class="card-price" style="font-size: clamp(12px, 1.2vw, 14px);"><%= (item.price * 1.1).floor %>円</p>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
・管理者側の商品編集画面で販売停止にしても変更されなかったバグ修正。
・加えて、更新ボタンを押しても反応しないバグも修正→テーブルタグの外にform_with出してないと起こるエラーっぽいです。しらんかった。
・販売停止したら、一覧に販売停止と表示されるように変更。顧客側は販売停止アイテムは非表示に。
・販売停止商品がカート内にある場合、情報入力へ進むボタンを非表示。
加えてメッセージも表示＆販売停止商品のみ削除できるボタン表示。
・前回プルリクした、トップ画像の新着商品横の商品一覧ボタン真ん中へ戻しました。見にくかった‥
・トップ画像の文章背景に黒い透かし。位置も再調整。


＜ご相談＞
①トップ画像に重ねてる「ようこそながのケーキへ～」なんですが、ログインしたら消すようにしました。ログインしてるのにログイン必要だよって言われるのしつこいかなって。いかがでしょうか？？
②カート内一覧の「買い物続ける」が「トップへ戻る」になっている件ですが、確かに遷移先はあっているのですが、UIフローには「買い物続けるボタンを押すとTop画面に戻る」とあるので、買い物続けるに戻してます。ただそれだと優しくないので、買い物続ける（Topへ）と買い物続ける（商品一覧）の二つを作成してます。いかがでしょうか？？